### PR TITLE
fix: use structural rpm query for signature key ID check (replace grep on free-text output)

### DIFF
--- a/scripts/xlion-repo-rpm-sign-packages
+++ b/scripts/xlion-repo-rpm-sign-packages
@@ -203,7 +203,7 @@ verify_or_retry() {
 
 main() {
   parse_args "$@"
-  check_dependencies find grep rpmkeys rpmsign sleep sort
+  check_dependencies find grep rpm rpmkeys rpmsign sleep sort
 
   if [[ ${#DIRS[@]} -eq 0 ]]; then
     error "At least one --dir is required."

--- a/scripts/xlion-repo-rpm-sign-packages
+++ b/scripts/xlion-repo-rpm-sign-packages
@@ -154,7 +154,10 @@ has_signature() {
   rpmkeys -Kv "$rpm_file" >&2
   echo "== end ==" >&2
 
-  rpmkeys -Kv "$rpm_file" | grep -qi -- "$GPG_KEY"
+  # Verify signature structurally: query RPM metadata for Signature field.
+  # rpm -qip produces structured output; grepping only the Signature line
+  # avoids matching filename or free-text output that may contain the key ID.
+  rpm -qip "$rpm_file" 2>/dev/null | grep -qi "Signature.*${GPG_KEY}\b"
 }
 
 sign_rpm() {


### PR DESCRIPTION
## Summary

Fixes a signature verification weakness in `xlion-repo-rpm-sign-packages` where `has_signature()` used `rpmkeys -Kv | grep` to check for the GPG key ID.

### Problem

```bash
rpmkeys -Kv "$rpm_file" | grep -qi -- "$GPG_KEY"
```

`rpmkeys -Kv` output includes the **filename** in its output. An RPM file named `my-package-8eba83b8.rpm` would cause grep to match the key ID embedded in the filename path, not in the actual signature result — producing a false positive.

### Fix

Replace with `rpm -qip`, which outputs **structured** package metadata:

```bash
rpm -qip "$rpm_file" 2>/dev/null | grep -qi "Signature.*${GPG_KEY}\b"
```

- The `Signature` field is a single well-defined line per package query
- `\b` word boundary ensures exact key ID match
- Filenames can't pollute the match because `rpm -qip` doesn't output filenames

### Why `rpm -qip` and not `rpmkeys -K` exit code?

`rpmkeys -K` exit code only tells us "is there a valid signature?" — it doesn't tell us **whose** signature. We need to confirm the package was signed with **our** key specifically.

### Validation

- [x] `bash -n` syntax check passes
- Backward compatible: same function signature, same return semantics
- No new dependencies (`rpm` is already installed; `rpmkeys` itself requires it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of RPM package signature verification to better detect authentically signed packages.
* **Chores**
  * Added an explicit runtime requirement for the rpm command-line tool.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xlionjuan/fedora-createrepo-image/pull/383)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xlionjuan/fedora-createrepo-image/pull/383)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->