### PR TITLE
Add container SBOM attestations

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -144,6 +144,18 @@ jobs:
           sbom-path: sbom-${{ matrix.job.name }}.spdx.json
           push-to-registry: true
 
+      - name: Attest SBOM with cosign (main)
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.push-main.outputs.digest }}
+          SBOM: sbom-${{ matrix.job.name }}.spdx.json
+        run: |
+          set -euo pipefail
+          cosign attest --yes \
+            --predicate "$SBOM" \
+            --type https://spdx.dev/Document/v2.3 \
+            "$IMAGE"
+
       - name: Write digest to file
         shell: bash
         run: |

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -125,6 +125,25 @@ jobs:
           extra-args: |
             --compression-format=zstd
 
+      - name: Generate SBOM (main)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/${{ github.repository }}@${{ steps.push-main.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-${{ matrix.job.name }}.spdx.json
+          artifact-name: sbom-${{ github.sha }}-${{ matrix.job.name }}.spdx.json
+          upload-artifact: true
+          upload-release-assets: false
+
+      - name: Attest SBOM (main)
+        uses: actions/attest@c32b4b8b198b65d0bd9d63490e847ff7b53989d4 # v4.0.0
+        if: github.event_name != 'pull_request'
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push-main.outputs.digest }}
+          sbom-path: sbom-${{ matrix.job.name }}.spdx.json
+          push-to-registry: true
+
       - name: Write digest to file
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ jobs:
 
 The container will be signed with [cosign](https://github.com/sigstore/cosign) and [GitHub Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds), you can verify the container before you using it in the workflow.
 
+The build also publishes an SPDX JSON SBOM for each architecture image and attaches it as a GitHub SBOM attestation to the pushed image digest. The SBOM is generated from the built container image, so it reflects the RPM packages, Ruby gems, and scripts that are actually present in the image. Since `latest` is a multi-architecture manifest tag, verify SBOM attestations against an architecture-specific tag such as `latest-amd64` or `latest-arm64`.
+
 This is an example workflow for verifying the container before using the container.
 
 ```yaml
@@ -82,6 +84,15 @@ jobs:
           env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: gh attestation verify --owner xlionjuan oci://ghcr.io/xlionjuan/fedora-createrepo-image:latest
+
+        - name: Verify SBOM attestation with gh
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            gh attestation verify \
+              --owner xlionjuan \
+              --predicate-type https://spdx.dev/Document/v2.3 \
+              oci://ghcr.io/xlionjuan/fedora-createrepo-image:latest-amd64
 
     build:
       runs-on: ubuntu-24.04-arm

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
 
 The container will be signed with [cosign](https://github.com/sigstore/cosign) and [GitHub Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds), you can verify the container before you using it in the workflow.
 
-The build also publishes an SPDX JSON SBOM for each architecture image and attaches it as a GitHub SBOM attestation to the pushed image digest. The SBOM is generated from the built container image, so it reflects the RPM packages, Ruby gems, and scripts that are actually present in the image. Since `latest` is a multi-architecture manifest tag, verify SBOM attestations against an architecture-specific tag such as `latest-amd64` or `latest-arm64`.
+The build also publishes an SPDX JSON SBOM for each architecture image and attaches the same SBOM as both a GitHub SBOM attestation and a cosign SBOM attestation to the pushed image digest. The SBOM is generated from the built container image, so it reflects the RPM packages, Ruby gems, and scripts that are actually present in the image. Since `latest` is a multi-architecture manifest tag, verify SBOM attestations against an architecture-specific tag such as `latest-amd64` or `latest-arm64`.
 
 This is an example workflow for verifying the container before using the container.
 
@@ -76,6 +76,14 @@ jobs:
             --certificate-identity-regexp "https://github.com/xlionjuan/.*" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             ghcr.io/xlionjuan/fedora-createrepo-image:latest
+
+        - name: Verify SBOM attestation with cosign
+          run: |
+            cosign verify-attestation \
+            --type https://spdx.dev/Document/v2.3 \
+            --certificate-identity-regexp "https://github.com/xlionjuan/.*" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            ghcr.io/xlionjuan/fedora-createrepo-image:latest-amd64
 
         # Unfortunately, gh can't do anything without login, even just `gh attestation verify` command
         # so it needs to login, but NO any permissions are required.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ jobs:
 
 The container will be signed with [cosign](https://github.com/sigstore/cosign) and [GitHub Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds), you can verify the container before you using it in the workflow.
 
-The build also publishes an SPDX JSON SBOM for each architecture image and attaches the same SBOM as both a GitHub SBOM attestation and a cosign SBOM attestation to the pushed image digest. The SBOM is generated from the built container image, so it reflects the RPM packages, Ruby gems, and scripts that are actually present in the image. Since `latest` is a multi-architecture manifest tag, verify SBOM attestations against an architecture-specific tag such as `latest-amd64` or `latest-arm64`.
+The build also publishes an SPDX JSON SBOM for each architecture image and attaches the same SBOM as both a GitHub SBOM attestation and a cosign SBOM attestation to the pushed image digest. The SBOM is generated from the built container image, so it reflects the RPM packages, Ruby gems, and scripts that are actually present in the image.
+
+For workflows that verify the container before using it, resolve the `latest` tag to a digest first, verify that immutable digest, and use the same digest in later jobs. This avoids a time-of-check/time-of-use race where `latest` changes after verification but before the container job starts.
 
 This is an example workflow for verifying the container before using the container.
 
@@ -62,6 +64,8 @@ jobs:
     verify:
       name: Verify container
       runs-on: ubuntu-24.04-arm
+      outputs:
+        digest: ${{ steps.get-digest.outputs.digest }}
       steps:
         # If you want to use cosign to verify the container, you should install cosign first.
 
@@ -70,20 +74,34 @@ jobs:
         - name: Install Cosign
           uses: sigstore/cosign-installer@v4.1.1
 
+        # Resolve the floating tag once, then verify and use this exact digest.
+        - name: Get image digest
+          id: get-digest
+          run: |
+            set -euo pipefail
+            digest="$(skopeo inspect --format '{{.Digest}}' docker://ghcr.io/xlionjuan/fedora-createrepo-image:latest)"
+            test -n "$digest"
+            echo "Resolved digest: ${digest}"
+            echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
         - name: Verify with cosign
           run: |
             cosign verify --rekor-url=https://rekor.sigstore.dev \
             --certificate-identity-regexp "https://github.com/xlionjuan/.*" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            ghcr.io/xlionjuan/fedora-createrepo-image:latest
+            ghcr.io/xlionjuan/fedora-createrepo-image@${{ steps.get-digest.outputs.digest }}
 
-        - name: Verify SBOM attestation with cosign
+        # Optional: verify the SBOM attestation with cosign.
+        # SBOMs are attached to architecture-specific image digests, not the
+        # multi-architecture `latest` manifest. Use the tag matching the
+        # runner architecture, such as `latest-amd64` or `latest-arm64`.
+        - name: Verify SBOM attestation with cosign (optional)
           run: |
             cosign verify-attestation \
             --type https://spdx.dev/Document/v2.3 \
             --certificate-identity-regexp "https://github.com/xlionjuan/.*" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            ghcr.io/xlionjuan/fedora-createrepo-image:latest-amd64
+            ghcr.io/xlionjuan/fedora-createrepo-image:latest-arm64
 
         # Unfortunately, gh can't do anything without login, even just `gh attestation verify` command
         # so it needs to login, but NO any permissions are required.
@@ -91,21 +109,24 @@ jobs:
         - name: Verify with gh
           env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          run: gh attestation verify --owner xlionjuan oci://ghcr.io/xlionjuan/fedora-createrepo-image:latest
+          run: gh attestation verify --owner xlionjuan oci://ghcr.io/xlionjuan/fedora-createrepo-image@${{ steps.get-digest.outputs.digest }}
 
-        - name: Verify SBOM attestation with gh
+        # Optional: verify the SBOM attestation with GitHub CLI.
+        # Like the cosign SBOM check above, this must target an
+        # architecture-specific image tag or digest.
+        - name: Verify SBOM attestation with gh (optional)
           env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
             gh attestation verify \
               --owner xlionjuan \
               --predicate-type https://spdx.dev/Document/v2.3 \
-              oci://ghcr.io/xlionjuan/fedora-createrepo-image:latest-amd64
+              oci://ghcr.io/xlionjuan/fedora-createrepo-image:latest-arm64
 
     build:
       runs-on: ubuntu-24.04-arm
       needs: verify # So this will only runs if "verify" is passed.
-      container: ghcr.io/xlionjuan/fedora-createrepo-image:latest
+      container: ghcr.io/xlionjuan/fedora-createrepo-image@${{ needs.verify.outputs.digest }}
       steps:
         - name: Checkout code
           uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Summary
- generate SPDX JSON SBOMs for each pushed architecture image
- attest the same SBOMs to the pushed GHCR image digests with both GitHub Artifact Attestations and cosign attestations on non-PR builds
- document digest-pinned container verification so callers resolve latest once, verify that digest, and use the same digest in container jobs
- document SBOM attestation verification with both gh and cosign, marked optional and architecture-specific

## Tests
- git diff --check
- python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/build_all.yml")); print("ok")'
- actionlint -shellcheck= .github/workflows/build_all.yml
- actionlint .github/workflows/build_all.yml

Note: full actionlint still reports pre-existing shellcheck style/info warnings in existing run blocks; the workflow syntax check passes with shellcheck disabled.