### PR TITLE
fix: validate rpm signature from rpmkeys result

### DIFF
--- a/scripts/xlion-repo-rpm-sign-packages
+++ b/scripts/xlion-repo-rpm-sign-packages
@@ -149,15 +149,28 @@ collect_rpms() {
 
 has_signature() {
   local rpm_file="$1"
+  local first_line=1
+  local key_lc="${GPG_KEY,,}"
+  local line
+  local line_lc
 
   echo "== rpmkeys output for $rpm_file ==" >&2
   rpmkeys -Kv "$rpm_file" >&2
   echo "== end ==" >&2
 
-  # Verify signature structurally: query RPM metadata for Signature field.
-  # rpm -qip produces structured output; grepping only the Signature line
-  # avoids matching filename or free-text output that may contain the key ID.
-  rpm -qip "$rpm_file" 2>/dev/null | grep -qi "Signature.*${GPG_KEY}\b"
+  while IFS= read -r line; do
+    if (( first_line )); then
+      first_line=0
+      continue
+    fi
+
+    line_lc="${line,,}"
+    if [[ "$line_lc" == *signature* && "$line_lc" == *"$key_lc"* && "$line_lc" == *": ok"* ]]; then
+      return 0
+    fi
+  done < <(rpmkeys -Kv "$rpm_file" 2>/dev/null)
+
+  return 1
 }
 
 sign_rpm() {
@@ -203,7 +216,7 @@ verify_or_retry() {
 
 main() {
   parse_args "$@"
-  check_dependencies find grep rpm rpmkeys rpmsign sleep sort
+  check_dependencies find rpmkeys rpmsign sleep sort
 
   if [[ ${#DIRS[@]} -eq 0 ]]; then
     error "At least one --dir is required."


### PR DESCRIPTION
## Summary
- fix false negatives introduced by the rpm -qip signature check from #383
- inspect rpmkeys -Kv output while skipping the first filename line, so filenames cannot spoof the key ID
- require a signature line containing the expected key and : OK before accepting a package as signed

## Diagnosis
rustdesk-rpm-repo#56 failed after pulling the image built from #383. rpmkeys reported the package signature as OK, but rpm -qip did not emit a matching Signature line, causing xlion-repo-rpm-sign-packages to retry and fail.

## Tests
- bash -n scripts/xlion-repo-rpm-sign-packages
- scripts/xlion-repo-rpm-sign-packages --help
- git diff --check
- sample parser check: filename containing key does not pass; rpmkeys signature line with fingerprint and : OK passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced RPM package signature detection for more reliable verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xlionjuan/fedora-createrepo-image/pull/389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->