### PR TITLE
fix: set up buildx for imagetools metadata

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -230,6 +230,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
       - name: Get Date
         id: get-date
         shell: bash

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -231,7 +231,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Get Date
         id: get-date


### PR DESCRIPTION
## Summary
- install Docker Buildx with docker/setup-buildx-action before using imagetools metadata output
- fixes the hosted runner error: unknown flag: --metadata-file

## Context
PR #390 was merged and switched manifest digest capture to docker buildx imagetools create --metadata-file. The default Buildx bundled on the runner does not support that flag, so this PR sets up a newer pinned Buildx action first.

## Tests
- git diff --check HEAD~1..HEAD
- python3 YAML parse for .github/workflows/build_all.yml
- actionlint -shellcheck= .github/workflows/build_all.yml